### PR TITLE
Improve cards prompt

### DIFF
--- a/prompts.js
+++ b/prompts.js
@@ -17,6 +17,11 @@ Guidelines for creating excellent flashcards:
 • CRITICAL: Keep answers as brief as possible while maintaining accuracy - aim for 10-25 words max
 • When referencing the author or source, use their specific name rather than general phrases like "the author" or "this text" which won't make sense months later when the user is reviewing the cards
 • Try to cite the author or the source when discussing something that is not an established concept but rather a new take or theory or prediction. 
+• The questions should be precise and unambiguously exclude alternative correct answers
+• The questions should encode ideas from multiple angles
+• Avoid yes/no question, or, in general, questions that admit a binary answer
+• Avoid unordered lists of items (especially if they contain many items)
+• If quantities are involved, they should be relative, or the unit of measure should be specified in the question
 
 You will also analyze the content and suggest an appropriate deck category.
 The specific deck options will be dynamically determined and provided in the user message.


### PR DESCRIPTION
The prompt that generates cards is already pretty good, I've added a few guidelines I've collected from a few resources on the topic.

Does the `Generate between 1-5 cards` instruction reflect your personal preference? Or is it there to help Claude generate better cards?
I guess it complements well the highlight UI interaction. Take for example a section of an article, you can highlight the whole section and get 5 cards for a high level picture, or use multiple separate highlights if you want more cards and more details.
An alternative idea could be adding a input field where the user can type instructions like "just 2-3 high level cards" or "as many cards as you can, try to be exhaustive".

Resources on flashcards writing I like:
- [Bjornstad - Rules for Designing Precise Anki Cards](https://controlaltbackspace.org/precise/)
- [Borretti - Effective Spaced Repetition](https://borretti.me/article/effective-spaced-repetition)
- [Matuschak - How to write good prompts: using spaced repetition to create understanding](https://andymatuschak.org/prompts/)
- [Nielsen - Augmenting Long-term Memory](https://augmentingcognition.com/ltm.html)
- [Nielsen - Using spaced repetition systems to see through a piece of mathematics](https://cognitivemedium.com/srs-mathematics)
- [Wozniak - Effective learning: Twenty rules of formulating knowledge](https://www.supermemo.com/en/blog/twenty-rules-of-formulating-knowledge)
- [Wozniak - Knowledge structuring and representation in learning based on active recall](https://www.supermemo.com/en/blog/knowledge-structuring-and-representation-in-learning-based-on-active-recall)
