### PR TITLE
refactor: remove Mochi references and update Claude model

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -19,8 +19,7 @@ module.exports = (req, res) => {
     status: 'ok', 
     message: 'Flash Card Generator API is running. Client-side API keys required.',
     apis: {
-      claude: 'Connected via /api/analyze-text and /api/generate-cards',
-      mochi: 'Connected via /api/mochi-decks and /api/upload-to-mochi'
+      claude: 'Connected via /api/analyze-text and /api/generate-cards'
     },
     timestamp: new Date().toISOString(),
     version: '1.0.0'

--- a/prompts.js
+++ b/prompts.js
@@ -64,7 +64,7 @@ module.exports = {
   // Common API configuration
   API_CONFIG: {
     ANTHROPIC_API_URL: "https://api.anthropic.com/v1/messages",
-    CLAUDE_MODEL: "claude-3-7-sonnet-20250219",
+    CLAUDE_MODEL: "claude-sonnet-4-6",
     ANTHROPIC_VERSION: "2023-06-01",
     PROMPTS
   }

--- a/server/server.js
+++ b/server/server.js
@@ -1,8 +1,7 @@
 /**
  * Flash Cards Generator API Server
- * 
+ *
  * Provides endpoints for generating flashcards using Claude API
- * and integrating with Mochi Cards
  */
 
 // Load .env file if present (for local development only)

--- a/src/claude-api.js
+++ b/src/claude-api.js
@@ -5,7 +5,9 @@
  */
 
 // Local storage key for API keys
-const API_KEY_STORAGE_KEY = "mochi_card_generator_api_keys";
+const FLASHCARD_STORAGE_KEY = "flashcard_generator_api_keys";
+// Legacy key from when the app used Mochi — kept for migration only
+const LEGACY_MOCHI_STORAGE_KEY = "mochi_card_generator_api_keys";
 
 /**
  * Retrieves stored API keys from local storage
@@ -13,29 +15,35 @@ const API_KEY_STORAGE_KEY = "mochi_card_generator_api_keys";
  */
 function getStoredApiKeys() {
   try {
-    const storedData = localStorage.getItem(API_KEY_STORAGE_KEY);
+    const storedData = localStorage.getItem(FLASHCARD_STORAGE_KEY);
     if (storedData) {
       return JSON.parse(storedData);
+    }
+    // Migrate from legacy storage key
+    const legacyData = localStorage.getItem(LEGACY_MOCHI_STORAGE_KEY);
+    if (legacyData) {
+      const parsed = JSON.parse(legacyData);
+      localStorage.setItem(FLASHCARD_STORAGE_KEY, legacyData);
+      localStorage.removeItem(LEGACY_MOCHI_STORAGE_KEY);
+      return parsed;
     }
   } catch (error) {
     console.error('Error reading stored API keys:', error);
   }
-  return { anthropicApiKey: null, mochiApiKey: null };
+  return { anthropicApiKey: null };
 }
 
 /**
  * Stores API keys in local storage
  * @param {string} anthropicApiKey - Claude API key
- * @param {string} mochiApiKey - Mochi API key
  * @param {boolean} storeLocally - Whether to store keys locally
  * @returns {boolean} Success status
  */
-function storeApiKeys(anthropicApiKey, mochiApiKey, storeLocally = true) {
+function storeApiKeys(anthropicApiKey, storeLocally = true) {
   if (storeLocally) {
     try {
-      localStorage.setItem(API_KEY_STORAGE_KEY, JSON.stringify({
-        anthropicApiKey,
-        mochiApiKey
+      localStorage.setItem(FLASHCARD_STORAGE_KEY, JSON.stringify({
+        anthropicApiKey
       }));
       return true;
     } catch (error) {
@@ -44,7 +52,7 @@ function storeApiKeys(anthropicApiKey, mochiApiKey, storeLocally = true) {
     }
   } else {
     try {
-      localStorage.removeItem(API_KEY_STORAGE_KEY);
+      localStorage.removeItem(FLASHCARD_STORAGE_KEY);
     } catch (error) {
       console.error('Error clearing API keys:', error);
     }

--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,7 @@
                                 <span class="menu-icon"></span>
                             </button>
                             <div class="dropdown-menu" id="dropdown-menu">
-                                <button id="exportButton" disabled class="dropdown-item">Export to Mochi</button>
+                                <button id="exportButton" disabled class="dropdown-item">Export as Markdown</button>
                                 <button id="clearCardsButton" disabled class="dropdown-item">Clear Cards</button>
                                 <button id="settingsButton" class="dropdown-item">API Keys</button>
                             </div>
@@ -84,17 +84,6 @@
                         Required to generate cards. Get your API key from <a href="https://console.anthropic.com/keys" target="_blank">console.anthropic.com/keys</a>
                     </div>
                     <div id="anthropicApiKeyError" class="api-key-error"></div>
-                </div>
-                
-                <div class="api-key-input-group">
-                    <label for="mochiApiKey">
-                        Mochi API Key
-                        <span class="optional">Optional</span>
-                    </label>
-                    <input type="text" id="mochiApiKey" placeholder="Your Mochi API key (optional)" autocomplete="off">
-                    <div class="api-key-help">
-                        Optional - lets you export directly to Mochi. Without this, cards can still be exported as markdown.
-                    </div>
                 </div>
                 
                 <div class="api-key-toggle">

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -15,7 +15,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const apiKeyModal = document.getElementById('apiKeyModal');
     const settingsButton = document.getElementById('settingsButton');
     const anthropicApiKeyInput = document.getElementById('anthropicApiKey');
-    const mochiApiKeyInput = document.getElementById('mochiApiKey');
     const storeLocallyCheckbox = document.getElementById('storeLocallyCheckbox');
     const apiKeySaveButton = document.getElementById('apiKeySave');
     const apiKeyCancelButton = document.getElementById('apiKeyCancel');
@@ -53,12 +52,6 @@ document.addEventListener('DOMContentLoaded', () => {
     if (storedKeys.anthropicApiKey) {
         // Pre-fill the form with stored keys (masked)
         anthropicApiKeyInput.value = storedKeys.anthropicApiKey;
-        if (storedKeys.mochiApiKey) {
-            mochiApiKeyInput.value = storedKeys.mochiApiKey;
-            // Fetch decks right away if we have a Mochi API key
-            fetchDecks()
-                .catch(error => console.error('Failed to load Mochi decks on startup:', error));
-        }
     } else {
         // Show API key modal on startup if no API keys are stored
         showApiKeyModal();
@@ -68,39 +61,24 @@ document.addEventListener('DOMContentLoaded', () => {
     settingsButton.addEventListener('click', showApiKeyModal);
     
     // Save button in API key modal
-    apiKeySaveButton.addEventListener('click', async () => {
+    apiKeySaveButton.addEventListener('click', () => {
         const anthropicKey = anthropicApiKeyInput.value.trim();
-        const mochiKey = mochiApiKeyInput.value.trim();
         const storeLocally = storeLocallyCheckbox.checked;
-        
+
         // Validate the Anthropic API key
         if (!validateAnthropicApiKey(anthropicKey)) {
             anthropicApiKeyError.textContent = 'Required: Enter a valid Claude API key (starts with sk-ant-)';
             anthropicApiKeyInput.focus();
             return;
         }
-        
-        // Store the API keys
-        const saveSuccess = storeApiKeys(anthropicKey, mochiKey, storeLocally);
-        
+
+        // Store the API key
+        const saveSuccess = storeApiKeys(anthropicKey, storeLocally);
+
         if (saveSuccess) {
             // Close the modal
             apiKeyModal.style.display = 'none';
-            
-            // Update UI based on available keys
-            updateUiForApiKeys();
-            
-            // Fetch decks if Mochi API key is provided
-            if (mochiKey) {
-                try {
-                    await fetchDecks();
-                    // Mochi decks successfully fetched
-                } catch (error) {
-                    console.error('Failed to fetch Mochi decks:', error);
-                    showNotification('Failed to connect to Mochi API', 'error');
-                }
-            }
-            
+
             // Show success notification
             showNotification('API keys saved successfully', 'success');
         } else {
@@ -126,30 +104,19 @@ document.addEventListener('DOMContentLoaded', () => {
     function showApiKeyModal() {
         // Reset error message
         anthropicApiKeyError.textContent = '';
-        
+
         // Fill in the form with stored values if available
         const storedKeys = getStoredApiKeys();
         if (storedKeys.anthropicApiKey) {
             anthropicApiKeyInput.value = storedKeys.anthropicApiKey;
         }
-        if (storedKeys.mochiApiKey) {
-            mochiApiKeyInput.value = storedKeys.mochiApiKey;
-        }
-        
+
         // Show the modal
         apiKeyModal.style.display = 'flex';
     }
     
     function updateUiForApiKeys() {
-        const keys = getStoredApiKeys();
-        
-        // Update export button text based on whether we have a Mochi API key
-        const exportButton = document.getElementById('exportButton');
-        if (keys.mochiApiKey) {
-            exportButton.textContent = 'Export to Mochi';
-        } else {
-            exportButton.textContent = 'Export as Markdown';
-        }
+        // No dynamic updates needed; export button is always "Export as Markdown"
     }
     
     // Call this on startup to set up the UI correctly
@@ -266,118 +233,11 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
     
-    // Fetch decks from Mochi API
-    async function fetchDecks() {
-        try {
-            // Check if we have a client-side Mochi API key
-            const { mochiApiKey } = getStoredApiKeys();
-            
-            if (!mochiApiKey) {
-                // Use fallback decks when no Mochi API key is available
-                state.decks = { "General": "general" };
-                state.currentDeck = "General";
-                
-                // Update export button text
-                const exportButton = document.getElementById('exportButton');
-                if (exportButton) {
-                    exportButton.textContent = 'Export as Markdown';
-                }
-                
-                return;
-            }
-            
-            // First try to use the server endpoint with user's API key
-            try {
-                // Pass the user's Mochi API key to the server endpoint
-                const response = await fetch(`/api/mochi-decks?userMochiKey=${encodeURIComponent(mochiApiKey)}`);
-                
-                if (response.ok) {
-                    const data = await response.json();
-                    
-                    if (data.success && data.decks) {
-                        // Store the decks in the state
-                        state.decks = data.decks;
-                        
-                        // Set currentDeck to first deck in the list
-                        state.currentDeck = Object.keys(data.decks)[0] || "General";
-                        // Decks loaded successfully
-                        return;
-                    }
-                }
-            } catch (serverError) {
-                // Server-side API failed, trying client-side API next
-            }
-            
-            // If server-side fails, try client-side API
-            if (mochiApiKey) {
-                // Mochi uses HTTP Basic Auth with API key followed by colon
-                const authHeader = `Basic ${btoa(`${mochiApiKey}:`)}`;
-                
-                try {
-                    // Directly call Mochi API from the client
-                    const response = await fetch('https://app.mochi.cards/api/decks/', {
-                        method: 'GET',
-                        headers: {
-                            'Authorization': authHeader
-                        }
-                    });
-                    
-                    if (!response.ok) {
-                        throw new Error(`Mochi API Error: ${await response.text()}`);
-                    }
-                    
-                    const decksData = await response.json();
-                    
-                    // Transform data for client use
-                    const formattedDecks = {};
-                    let activeDecksCount = 0;
-                    
-                    decksData.docs.forEach(deck => {
-                        // Skip decks that are in trash or archived
-                        if (deck['trashed?'] || deck['archived?']) {
-                            return; // Skip this deck
-                        }
-                        
-                        // Only include active decks
-                        activeDecksCount++;
-                        
-                        // Remove [[ ]] if present in the ID
-                        const cleanId = deck.id.replace(/\[\[|\]\]/g, '');
-                        formattedDecks[deck.name] = cleanId;
-                    });
-                    
-                    // Successfully loaded active decks from Mochi API
-                    
-                    // Store the decks in the state
-                    state.decks = formattedDecks;
-                    
-                    // Set currentDeck to first deck in the list
-                    state.currentDeck = Object.keys(formattedDecks)[0] || "General";
-                    
-                    // Update export button text
-                    const exportButton = document.getElementById('exportButton');
-                    if (exportButton) {
-                        exportButton.textContent = 'Export to Mochi';
-                    }
-                    
-                    return;
-                } catch (clientApiError) {
-                    console.error('Error using client-side Mochi API:', clientApiError);
-                }
-            }
-            
-            // Create deck selector dropdown
-            createDeckSelector();
-            
-        } catch (error) {
-            console.error('Error fetching decks:', error);
-            // Fallback to a simple deck structure
-            state.decks = { "General": "general" };
-            state.currentDeck = "General";
-            
-            // Create deck selector with fallback
-            createDeckSelector();
-        }
+    // Initialize deck state with defaults
+    function fetchDecks() {
+        state.decks = { "General": "general" };
+        state.currentDeck = "General";
+        return Promise.resolve();
     }
     
     // Function to show status notifications
@@ -423,7 +283,7 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Event Listeners
     generateButton.addEventListener('click', generateCardsFromSelection);
-    exportButton.addEventListener('click', exportToMochi);
+    exportButton.addEventListener('click', exportAsMarkdown);
     clearCardsButton.addEventListener('click', clearAllCards);
     
     // Initialize Quill editor
@@ -483,7 +343,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initialize UI and fetch decks
     updateButtonStates();
     
-    // Fetch decks from Mochi API on startup
+    // Initialize deck state on startup
     fetchDecks().catch(error => {
         console.error('Error initializing decks:', error);
         // Create a fallback deck selector in case of error
@@ -784,7 +644,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const deckNames = Object.keys(state.decks);
         
         if (deckNames.length === 0) {
-            showNotification('No decks available. Please check Mochi connection.', 'error');
+            showNotification('No decks available.', 'error');
             return;
         }
         
@@ -812,7 +672,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Add a refresh button
         const refreshButton = document.createElement('button');
         refreshButton.className = 'modal-refresh-button';
-        refreshButton.title = 'Refresh deck list from Mochi';
+        refreshButton.title = 'Refresh deck list';
         refreshButton.innerHTML = '↻';
         refreshButton.addEventListener('click', () => {
             refreshButton.disabled = true;
@@ -933,68 +793,6 @@ document.addEventListener('DOMContentLoaded', () => {
     // clearAllQuestions function removed
     
     
-    async function exportToMochi() {
-        try {
-            // Check if we have any cards to export
-            if (state.cards.length === 0) {
-                showNotification('No cards to export', 'info');
-                return;
-            }
-            
-            // Get the stored API keys
-            const { mochiApiKey } = getStoredApiKeys();
-            
-            // If no Mochi API key, export as markdown instead
-            if (!mochiApiKey) {
-                exportAsMarkdown();
-                return;
-            }
-            
-            // If we have a Mochi API key, prepare the cards for Mochi
-            const mochiData = formatCardsForMochi();
-            const cards = JSON.parse(mochiData).cards;
-            
-            // Show loading indicator
-            exportButton.disabled = true;
-            exportButton.textContent = 'Uploading...';
-            
-            // Use the server endpoint to handle Mochi uploads, passing the user's API key
-            const response = await fetch('/api/upload-to-mochi', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({ 
-                    cards,
-                    userMochiKey: mochiApiKey // Pass the user's Mochi API key to the server
-                })
-            });
-            
-            if (!response.ok) {
-                throw new Error('Failed to upload to Mochi');
-            }
-            
-            const result = await response.json();
-            
-            // Success notification
-            showNotification(`${result.totalSuccess} of ${result.totalCards} cards uploaded to Mochi successfully!`, 'success');
-            
-        } catch (error) {
-            console.error('Error uploading to Mochi API:', error);
-            showNotification('Error uploading to Mochi. Exporting as markdown instead.', 'error');
-            
-            // Fall back to markdown export
-            exportAsMarkdown();
-        } finally {
-            // Reset button state
-            exportButton.disabled = false;
-            
-            // Update button text based on whether we have a Mochi API key
-            const { mochiApiKey } = getStoredApiKeys();
-            exportButton.textContent = mochiApiKey ? 'Export to Mochi' : 'Export as Markdown';
-        }
-    }
-    
     function exportAsMarkdown() {
         if (state.cards.length === 0) {
             showNotification('No cards to export', 'info');
@@ -1069,50 +867,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
     // exportQuestions function removed
-    
-    function formatCardsForMochi() {
-        // Group cards by deck
-        const deckMap = {};
-        
-        state.cards.forEach(card => {
-            const deckName = card.deck;
-            const deckId = state.decks[deckName];
-            
-            if (!deckId) {
-                console.warn(`No deck ID found for deck: ${deckName}`);
-                return; // Skip this card
-            }
-            
-            if (!deckMap[deckId]) {
-                deckMap[deckId] = [];
-            }
-            
-            // Use the exact Mochi format: front \n---\n back (single newlines)
-            deckMap[deckId].push({
-                content: `${card.front}\n---\n${card.back}`
-            });
-        });
-        
-        // Format according to Mochi's JSON format
-        const data = {
-            version: 2,
-            cards: []
-        };
-        
-        // Add cards with their deck IDs
-        for (const [deckId, cards] of Object.entries(deckMap)) {
-            cards.forEach(card => {
-                data.cards.push({
-                    ...card,
-                    'deck-id': deckId
-                });
-            });
-        }
-        
-        console.log('Formatted cards for Mochi:', data);
-        return JSON.stringify(data, null, 2);
-    }
-    
+
     function downloadExport(data, filename) {
         const blob = new Blob([data], { type: 'application/json' });
         const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary

- **Update `CLAUDE_MODEL`** in `prompts.js` from `claude-3-7-sonnet-20250219` to `claude-sonnet-4-6`
- **Rename `API_KEY_STORAGE_KEY`** in `src/claude-api.js` to `FLASHCARD_STORAGE_KEY` (`"flashcard_generator_api_keys"`); legacy key `"mochi_card_generator_api_keys"` is migrated automatically on first load so no existing user loses their stored API key
- **Remove Mochi API key** from the settings modal (`src/index.html`) since the app now targets Anki exclusively
- **Clean up `src/scripts.js`**: remove `mochiApiKeyInput`, `exportToMochi`, `formatCardsForMochi`, and all Mochi deck-fetching logic; the export button now directly calls `exportAsMarkdown`; `fetchDecks` is simplified to set the default `"General"` deck
- **Clean up comments** in `server/server.js` and `api/index.js`

## Why this improves the codebase

The app originally targeted Mochi but now targets Anki. This PR removes dead Mochi-specific naming (variable names, function names, localStorage key, UI labels) throughout the frontend while preserving all card-generation functionality. The server-side Mochi API endpoints (`/api/mochi-decks`, `/api/upload-to-mochi`) are left in place as they still work independently, but the frontend no longer calls them.

## Test plan

- [ ] Open the app and verify the API key modal no longer shows a Mochi key field
- [ ] Enter a Claude API key and confirm it saves and persists across reloads
- [ ] Paste text, highlight a selection, generate cards
- [ ] Click "Export as Markdown" and confirm a `.md` file downloads
- [ ] Verify users who had a key stored under the old `mochi_card_generator_api_keys` key are migrated (key moved to `flashcard_generator_api_keys`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)